### PR TITLE
Refactor fretboard plotter

### DIFF
--- a/python_fretboard_plotter/fretboard_plotter.py
+++ b/python_fretboard_plotter/fretboard_plotter.py
@@ -217,7 +217,16 @@ class FretboardPlotter:
 
 	@staticmethod
 	#index 0 = right handed plot, index 1 = left handed plot
-	def plot(plottables, graphTitle, filePath, instrument, tuning, night=True):
+	def plot(note, scaleOrChord, isScale, outputDestination, filePath, instrument, tuning, night=True):
+		listOfPlottables = []
+		plottable : Plottable = None
+		if isScale:
+			plottable = Plottable(note,FretboardPlotter.scalesToScaleIndexesDictionary[scaleOrChord])
+		else:
+			plottable = Plottable(note,FretboardPlotter.chordsToChordIndexesDictionary[scaleOrChord])
+		listOfPlottables.append(plottable)
+		graphTitle = "{} {}\n{}".format(note, scaleOrChord, FretboardPlotter.get_plottable_notes(plottable))
+
 		FretboardPlotter.populate_strings(instrument, tuning)
 		#creating two plots, top right handed, bottom left handed
 		fig, ax = plt.subplots(2, figsize=(21,6))
@@ -331,32 +340,31 @@ class Plottable:
 # Program Execution Logic Below
 
 # for each note, create every chord and every scale
+outputDestination = sys.argv[1]
+guitar = "guitar"
+bass = "bass"
+standardTuning = "standard"
+dropDTuning = "dropD" 
+fiveStringStandardTuning = "fiveStringStandard"
+fiveStringDropDTuning = "fiveStringDropD" 
+fiveStringDropATuning = "fiveStringDropA"
+
 allNotes = ['C', 'C#', 'Db', 'D', 'D#', 'Eb', 'E', 'F', 'F#', 'Gb' , 'G', 'G#', 'Ab', 'A', 'A#', 'Bb', 'B' ]
 for note in allNotes:
 	for scale in FretboardPlotter.scalesToScaleIndexesDictionary.keys():
-		listOfPlottables = []
-		plottable = Plottable(note,FretboardPlotter.scalesToScaleIndexesDictionary[scale])
-		listOfPlottables.append(plottable)
-		graphTitle = "{} {}\n{}".format(note, scale, FretboardPlotter.get_plottable_notes(plottable))
-		print(graphTitle)
-		FretboardPlotter.plot(listOfPlottables, graphTitle, "C:/Users/lukeb/Desktop/Fretboard Plotter Pics/{} {}".format(note, scale), "guitar", FretboardPlotter.tunings["guitar"]["standard"])
-		FretboardPlotter.plot(listOfPlottables, graphTitle, "C:/Users/lukeb/Desktop/Fretboard Plotter Pics/{} {}".format(note, scale), "bass", FretboardPlotter.tunings["bass"]["standard"])
-		FretboardPlotter.plot(listOfPlottables, graphTitle, "C:/Users/lukeb/Desktop/Fretboard Plotter Pics/{} {}".format(note, scale), "bass", FretboardPlotter.tunings["bass"]["fiveStringStandard"])
-		FretboardPlotter.plot(listOfPlottables, graphTitle, "C:/Users/lukeb/Desktop/Fretboard Plotter Pics/{} {}".format(note, scale), "guitar", FretboardPlotter.tunings["guitar"]["dropD"])
-		FretboardPlotter.plot(listOfPlottables, graphTitle, "C:/Users/lukeb/Desktop/Fretboard Plotter Pics/{} {}".format(note, scale), "bass", FretboardPlotter.tunings["bass"]["dropD"])
-		FretboardPlotter.plot(listOfPlottables, graphTitle, "C:/Users/lukeb/Desktop/Fretboard Plotter Pics/{} {}".format(note, scale), "bass", FretboardPlotter.tunings["bass"]["fiveStringDropD"])
-		FretboardPlotter.plot(listOfPlottables, graphTitle, "C:/Users/lukeb/Desktop/Fretboard Plotter Pics/{} {}".format(note, scale), "bass", FretboardPlotter.tunings["bass"]["fiveStringDropA"])
+		FretboardPlotter.plot(note, FretboardPlotter.scalesToScaleIndexesDictionary[scale], True, outputDestination.format(note, scale), guitar, FretboardPlotter.tunings[guitar][standardTuning])
+		FretboardPlotter.plot(note, FretboardPlotter.scalesToScaleIndexesDictionary[scale], True, outputDestination.format(note, scale), bass, FretboardPlotter.tunings[bass][standardTuning])
+		FretboardPlotter.plot(note, FretboardPlotter.scalesToScaleIndexesDictionary[scale], True, outputDestination.format(note, scale), bass, FretboardPlotter.tunings[bass][fiveStringStandardTuning])
+		FretboardPlotter.plot(note, FretboardPlotter.scalesToScaleIndexesDictionary[scale], True, outputDestination.format(note, scale), guitar, FretboardPlotter.tunings[guitar][dropDTuning])
+		FretboardPlotter.plot(note, FretboardPlotter.scalesToScaleIndexesDictionary[scale], True, outputDestination.format(note, scale), bass, FretboardPlotter.tunings[bass][dropDTuning])
+		FretboardPlotter.plot(note, FretboardPlotter.scalesToScaleIndexesDictionary[scale], True, outputDestination.format(note, scale), bass, FretboardPlotter.tunings[bass][fiveStringDropDTuning])
+		FretboardPlotter.plot(note, FretboardPlotter.scalesToScaleIndexesDictionary[scale], True, outputDestination.format(note, scale), bass, FretboardPlotter.tunings[bass][fiveStringDropATuning])
 	for chord in FretboardPlotter.chordsToChordIndexesDictionary.keys():
-		listOfPlottables = []
-		plottable = Plottable(note,FretboardPlotter.scalesToScaleIndexesDictionary[chord])
-		listOfPlottables.append(plottable)
-		graphTitle = "{} {}\n{}".format(note, chord, FretboardPlotter.get_plottable_notes(plottable))
-		print(graphTitle)
-		FretboardPlotter.plot(listOfPlottables, graphTitle, "C:/Users/lukeb/Desktop/Fretboard Plotter Pics/{} {}".format(note, chord), "guitar", FretboardPlotter.tunings["guitar"]["standard"])
-		FretboardPlotter.plot(listOfPlottables, graphTitle, "C:/Users/lukeb/Desktop/Fretboard Plotter Pics/{} {}".format(note, chord), "bass", FretboardPlotter.tunings["bass"]["standard"])
-		FretboardPlotter.plot(listOfPlottables, graphTitle, "C:/Users/lukeb/Desktop/Fretboard Plotter Pics/{} {}".format(note, chord), "bass", FretboardPlotter.tunings["bass"]["fiveStringStandard"])
-		FretboardPlotter.plot(listOfPlottables, graphTitle, "C:/Users/lukeb/Desktop/Fretboard Plotter Pics/{} {}".format(note, chord), "guitar", FretboardPlotter.tunings["guitar"]["dropD"])
-		FretboardPlotter.plot(listOfPlottables, graphTitle, "C:/Users/lukeb/Desktop/Fretboard Plotter Pics/{} {}".format(note, chord), "bass", FretboardPlotter.tunings["bass"]["dropD"])
-		FretboardPlotter.plot(listOfPlottables, graphTitle, "C:/Users/lukeb/Desktop/Fretboard Plotter Pics/{} {}".format(note, chord), "bass", FretboardPlotter.tunings["bass"]["fiveStringDropD"])
-		FretboardPlotter.plot(listOfPlottables, graphTitle, "C:/Users/lukeb/Desktop/Fretboard Plotter Pics/{} {}".format(note, chord), "bass", FretboardPlotter.tunings["bass"]["fiveStringDropA"])
+		FretboardPlotter.plot(note, FretboardPlotter.chordsToChordIndexesDictionary[chord], False, outputDestination.format(note, chord), guitar, FretboardPlotter.tunings[guitar][standardTuning])
+		FretboardPlotter.plot(note, FretboardPlotter.chordsToChordIndexesDictionary[chord], False, outputDestination.format(note, chord), bass, FretboardPlotter.tunings[bass][standardTuning])
+		FretboardPlotter.plot(note, FretboardPlotter.chordsToChordIndexesDictionary[chord], False, outputDestination.format(note, chord), bass, FretboardPlotter.tunings[bass][fiveStringStandardTuning])
+		FretboardPlotter.plot(note, FretboardPlotter.chordsToChordIndexesDictionary[chord], False, outputDestination.format(note, chord), guitar, FretboardPlotter.tunings[guitar][dropDTuning])
+		FretboardPlotter.plot(note, FretboardPlotter.chordsToChordIndexesDictionary[chord], False, outputDestination.format(note, chord), bass, FretboardPlotter.tunings[bass][dropDTuning])
+		FretboardPlotter.plot(note, FretboardPlotter.chordsToChordIndexesDictionary[chord], False, outputDestination.format(note, chord), bass, FretboardPlotter.tunings[bass][fiveStringDropDTuning])
+		FretboardPlotter.plot(note, FretboardPlotter.chordsToChordIndexesDictionary[chord], False, outputDestination.format(note, chord), bass, FretboardPlotter.tunings[bass][fiveStringDropATuning])
 

--- a/python_fretboard_plotter/fretboard_plotter.py
+++ b/python_fretboard_plotter/fretboard_plotter.py
@@ -13,6 +13,7 @@ import sys
 class FretboardPlotter:
 	# multiplying lists by 3 bc of populate strings method. looks 21 notes past the starting point of the strings, 
 	# 	so need to make sure there's enough notes to choose from
+	numFrets = 24
 	whole_notes_flats = ['C' , 'Db', 'D', 'Eb', 'E', 'F', 'Gb' , 'G', 'Ab', 'A', 'Bb', 'B']*3
 	whole_notes_sharps = ['C' , 'C#', 'D', 'D#', 'E', 'F', 'F#' , 'G', 'G#', 'A', 'A#', 'B']*3
 	strings = {}
@@ -191,7 +192,8 @@ class FretboardPlotter:
 			sharpsAndFlats = list(zip(FretboardPlotter.whole_notes_sharps, FretboardPlotter.whole_notes_flats))
 			#start = index of the first tuple containing E|A|D|G in sharpsAndFlats
 			start = [x[0] for x in sharpsAndFlats].index(i)
-			strings[i] = sharpsAndFlats[start:start+21]
+			# +1 for the open string
+			strings[i] = sharpsAndFlats[start:start+FretboardPlotter.numFrets + 1]
 		FretboardPlotter.strings = strings
 
 	# look at plottable notes being passed in. if sharp look for sharps, if flat look for flats
@@ -216,105 +218,107 @@ class FretboardPlotter:
 		return notes_strings
 
 	@staticmethod
-	#index 0 = right handed plot, index 1 = left handed plot
-	# TODO adjust neck area for different string lengths. Works fine on 6 string, 4 and 5 are a mess
-	# TODO currently generates 20 frets. add 4 more for 24
-	def plot(note, scaleOrChordDegree, scaleOrChordTuple, filePath : str, instrument, tuning, night=True):
-		listOfPlottables = []
-		plottable : Plottable = None
-		# ex scale or chord is a tuple, get right side ("(R 2nd 3rd 4th 5th 6th 7th)", [0, 2, 4, 5, 7, 9, 11])
-		plottable = Plottable(note, scaleOrChordTuple[1])
-		listOfPlottables.append(plottable)
-		graphTitle = "{} {}\n{}\n{}".format(note, scaleOrChordDegree, scaleOrChordTuple[0], FretboardPlotter.get_plottable_notes(plottable))
+	def plot(rootNote, scaleOrChordDegree, scaleOrChordTuple, filePath, instrument, tuning, night=True):
+		numFrets = FretboardPlotter.numFrets
+		nStrings = len(tuning)
+		listOfPlottables = [Plottable(rootNote, scaleOrChordTuple[1])]
+		graphTitle = "{} {}\n{}\n{}".format(
+			rootNote, scaleOrChordDegree, scaleOrChordTuple[0],
+			FretboardPlotter.get_plottable_notes(listOfPlottables[0]))
 
 		FretboardPlotter.populate_strings(instrument, tuning)
-		#creating two plots, top right handed, bottom left handed
-		fig, ax = plt.subplots(2, figsize=(21,len(tuning) + 1))
-		background = ['white', 'black']
-		# creates lines in each plot for each string
-		for i in range(1,len(tuning)):
-			for index, graph in enumerate(ax):
-				graph.plot([i for a in range(22)])
-				graph.set_axisbelow(True)
-				#setting height and width of displayed guitar
-				if index == 0:
-					graph.set_xlim([0.45, 21])
-				elif index == 1:
-					graph.set_xlim([0, 20.1])
-				graph.set_ylim([0.4, 6.5])
-				graph.set_facecolor(background[night])
-		
-		#creates the lines to simulate the fretboard in each graph
-		for i in range(1,21):
-			for index, graph in enumerate(ax):
-				# draw gray line completely around 12 fret
-				if (index == 0 and (i == 12 or i ==13)) or (index == 1 and (i == 8 or i == 9)):
-					graph.axvline(x=i, color='gray', linewidth=4.5)
-				# draw gold line before first fret to symbolize open notes
-				elif (i == 1 and index == 0) or (i == 20 and index == 1):
-					graph.axvline(x=i if index == 1 else i-.2, color='gold', linewidth=6.5)
-				else:
-					graph.axvline(x=i, color=background[night-1], linewidth=0.5)
 
-		to_plot  = {}
+		fig, ax = plt.subplots(2, figsize=(max(8, numFrets * 0.9), nStrings + 1))
+		background = ['white', 'black']
+		fretLineColor = background[night - 1]
+
+		# index 0 = right handed, index 1 = left handed
+		for index, graph in enumerate(ax):
+			graph.set_facecolor(background[night])
+			graph.set_axisbelow(True)
+			graph.set_ylim([0.4, nStrings + 0.6])
+			# board ends flush with the last fret; small gap behind the nut for the open labels
+			if index == 0:
+				graph.set_xlim([0.3, numFrets + 0.5])
+			else:
+				graph.set_xlim([-0.5, numFrets - 0.3])
+			# horizontal string lines (one plot call per string keeps the multi-color cycle)
+			for y in range(1, nStrings + 1):
+				graph.plot([-0.7, numFrets + 0.7], [y, y], zorder=1)
+			# vertical fret wires sit halfway between note slots; numFrets wires total
+			# (the nut + inner wires) -- no wire after the last fret
+			for w in range(numFrets):
+				xw = (w + 0.5) if index == 0 else (numFrets - w - 0.5)
+				if w == 0:                       # the nut
+					graph.axvline(x=xw, color='gold', linewidth=5.5, zorder=2)
+				elif w in (11, 12) and numFrets >= 12:  # emphasize the 12th fret
+					graph.axvline(x=xw, color='gray', linewidth=4.0, zorder=2)
+				else:
+					graph.axvline(x=xw, color=fretLineColor, linewidth=0.5, zorder=2)
+
+		# gather note positions
+		to_plot = {}
 		plottableRoots = []
 		for plottable in listOfPlottables:
 			plottableRoots.append(plottable.get_root())
-			#ex) notes = ['C', 'E', 'G']
 			notes = FretboardPlotter.get_plottable_notes(plottable)
-			#ex) plottableNootes = {'E': [0, 3, 8, 12, 15, 20], 'A': [3, 7, 10, 15, 19], 'D': [2, 5, 10, 14, 17], 'G': [0, 5, 9, 12, 17]
 			plottableNotes = FretboardPlotter.find_notes(notes, tuning)
-			# need to combine the dictionary lists together for multiple plottables
 			if len(to_plot) == 0:
 				to_plot = plottableNotes
 			else:
 				for key in to_plot.keys():
 					to_plot[key] += plottableNotes[key]
 
-		#find_notes returns a map of strings with the indexes of the notes that are in the given scale
-			#ex: to_plot(C major scale) = {'E': [19, 17, 15, 13, 12, 10, 8, 7, 5, 3, 1, 0], 'A': [19, 17, 15, 14, 12, 10, 8, 7, 5, 3, 2, 0]...
-			# below for loop iterates through EADGBE keys of the map
+		useFlats = any(pr in FretboardPlotter.accidentalsToKeysMap["flats"] for pr in plottableRoots)
 
-		# TODO need to figure out a way to draw certain strings twice if the tuning calls for it (ex; EADGBE, DADG)
-		# TODO saved a blank diagram for c major
-		#need to create a list of 1-n where n is number of strings or the length of the tuning string
-		for y_val, stringName in zip(list(range(1, len(tuning) + 1)), tuning):
-			#  looks up the values corresponding to EADGBE keys of find_notes map aka the indexes of the notes that were in the given scale
-			# ex) iterating through to_plot[E] = [19, 17, 15, 13, 12, 10, 8, 7, 5, 3, 1, 0]
+		def bubble(graph, x, y, note, isRoot):
+			graph.annotate(
+				note, (x, y), color=('yellow' if isRoot else 'white'),
+				weight='bold', fontsize=(14 if isRoot else 11), ha='center', va='center', zorder=3,
+				bbox=dict(boxstyle='circle,pad=0.32', facecolor='#1f77b4',
+						  edgecolor=('gold' if isRoot else 'none'), linewidth=(2.0 if isRoot else 0.0)))
+
+		# fretted notes only -- skip index 0 (open string); the open note is drawn on the axis
+		for y_val, stringName in zip(range(1, nStrings + 1), tuning):
 			for i in to_plot[stringName]:
-				font = 12
-				color = 'w'
-				circleSize = 0.2
-				# i = 0 means an open string note (E,A,D,G)
-				xLefty = (21 - i - 0.7) if i == 0 else (21 - i - 0.45)
-				xRighty = (i + 0.55) if i == 0 else (i + 0.55)
-				# strings is a map of each string and their notes. 
-				# gets the list of notes for a given string and looks up the note at the index
+				if i == 0:
+					continue
 				noteTuple = FretboardPlotter.strings[stringName][i]
-				note = noteTuple[1] if any(pr in FretboardPlotter.accidentalsToKeysMap["flats"] for pr in plottableRoots) else noteTuple[0]
-				# make the root slightly larger and yellow
-				if(note in plottableRoots):
-					font = 15
-					color = 'yellow'
-					circleSize = 0.3
+				note = noteTuple[1] if useFlats else noteTuple[0]
+				isRoot = note in plottableRoots
 				for index, graph in enumerate(ax):
-					p = mpatches.Circle((xRighty if index == 0 else xLefty, y_val), circleSize)
-					graph.add_patch(p)
-					graph.annotate(note, (xRighty if index == 0 else xLefty, y_val), color=color, weight='bold', fontsize=font, ha='center', va='center')
+					x = i if index == 0 else (numFrets - i)
+					bubble(graph, x, y_val, note, isRoot)
 
 		fig.suptitle(graphTitle)
-		# adding more space between the two graphs
-		plt.subplots_adjust(None, None, None, None, None, 0.5)
+		# reserve title room proportional to figure height so it never overlaps the board
+		plt.subplots_adjust(top=1 - 1.25 / (nStrings + 1), hspace=0.5, left=0.05, right=0.95)
 		for index, graph in enumerate(ax):
-			if index == 0:
-				graph.set_xticks(np.arange(21)+0.45, np.arange(0,21))
-			elif index == 1:
+			if index == 0:                       # right handed: frets 1..numFrets left-to-right
+				graph.set_xticks(range(1, numFrets + 1), range(1, numFrets + 1))
+			else:                                # left handed: frets numFrets..1 left-to-right
 				graph.yaxis.tick_right()
-				graph.set_xticks(np.arange(21)+0.45, np.arange(20,-1,-1))
-				graph.set_yticks(np.arange(1,len(tuning) + 1), list(tuning))
-		#plt.show()
-		# ex 'C major guitar - 6 string EADGBE'
-		plt.savefig(filePath + "/{} {} {} - {} string {}.png".format(note, scaleOrChordDegree, instrument, len(tuning), tuning))
+				graph.set_xticks(range(0, numFrets), range(numFrets, 0, -1))
+			graph.set_yticks(range(1, nStrings + 1), list(tuning))
+
+		# string labels: uniform size/weight for every string; circle the open-string
+		# note when it's in the scale/chord (gold ring + yellow when it's the root)
+		for index, graph in enumerate(ax):
+			for k, label in enumerate(graph.get_yticklabels()):
+				label.set_fontsize(12)
+				label.set_fontweight('bold')
+				stringName = list(tuning)[k]
+				if 0 not in to_plot[stringName]:
+					continue  # open note isn't in the scale/chord -> plain (but same size)
+				openNote = FretboardPlotter.strings[stringName][0][1 if useFlats else 0]
+				isRoot = openNote in plottableRoots
+				label.set_color('yellow' if isRoot else 'white')
+				label.set_bbox(dict(boxstyle='circle,pad=0.3', facecolor='#1f77b4',
+									 edgecolor=('gold' if isRoot else 'none'),
+									 linewidth=(2.0 if isRoot else 0.0)))
+
+		plt.savefig(filePath + "/{} {} {} - {} string {}.png".format(
+			rootNote, str(scaleOrChordDegree).replace("/", "|"), instrument, nStrings, tuning))
 		plt.close()
 
 # Anything that will be plotted on the fretboard

--- a/python_fretboard_plotter/fretboard_plotter.py
+++ b/python_fretboard_plotter/fretboard_plotter.py
@@ -217,7 +217,9 @@ class FretboardPlotter:
 
 	@staticmethod
 	#index 0 = right handed plot, index 1 = left handed plot
-	def plot(note, scaleOrChordDegree, scaleOrChordTuple, filePath, instrument, tuning, night=True):
+	# TODO adjust neck area for different string lengths. Works fine on 6 string, 4 and 5 are a mess
+	# TODO currently generates 20 frets. add 4 more for 24
+	def plot(note, scaleOrChordDegree, scaleOrChordTuple, filePath : str, instrument, tuning, night=True):
 		listOfPlottables = []
 		plottable : Plottable = None
 		# ex scale or chord is a tuple, get right side ("(R 2nd 3rd 4th 5th 6th 7th)", [0, 2, 4, 5, 7, 9, 11])
@@ -227,10 +229,10 @@ class FretboardPlotter:
 
 		FretboardPlotter.populate_strings(instrument, tuning)
 		#creating two plots, top right handed, bottom left handed
-		fig, ax = plt.subplots(2, figsize=(21,6))
+		fig, ax = plt.subplots(2, figsize=(21,len(tuning) + 1))
 		background = ['white', 'black']
-		# creates 6 lines in each plot for the 6 strings
-		for i in range(1,7):
+		# creates lines in each plot for each string
+		for i in range(1,len(tuning)):
 			for index, graph in enumerate(ax):
 				graph.plot([i for a in range(22)])
 				graph.set_axisbelow(True)
@@ -309,15 +311,10 @@ class FretboardPlotter:
 			elif index == 1:
 				graph.yaxis.tick_right()
 				graph.set_xticks(np.arange(21)+0.45, np.arange(20,-1,-1))
-			if instrument == "guitar":
-				graph.set_yticks(np.arange(1,7), list(tuning))
-			elif instrument == "bass" and "fiveString" in tuning:
-				 graph.set_yticks(np.arange(1,5),list(tuning))
-			elif instrument == "bass":
-				 graph.set_yticks(np.arange(1,5), list(tuning))
-			else: raise ValueError("{} or {} not recognized as tunings or instruments".format(instrument, tuning))
+				graph.set_yticks(np.arange(1,len(tuning) + 1), list(tuning))
 		#plt.show()
-		plt.savefig(filePath)
+		# ex 'C major guitar - 6 string EADGBE'
+		plt.savefig(filePath + "/{} {} {} - {} string {}.png".format(note, scaleOrChordDegree, instrument, len(tuning), tuning))
 		plt.close()
 
 # Anything that will be plotted on the fretboard

--- a/python_fretboard_plotter/fretboard_plotter.py
+++ b/python_fretboard_plotter/fretboard_plotter.py
@@ -217,15 +217,13 @@ class FretboardPlotter:
 
 	@staticmethod
 	#index 0 = right handed plot, index 1 = left handed plot
-	def plot(note, scaleOrChord, isScale, outputDestination, filePath, instrument, tuning, night=True):
+	def plot(note, scaleOrChordDegree, scaleOrChordTuple, filePath, instrument, tuning, night=True):
 		listOfPlottables = []
 		plottable : Plottable = None
-		if isScale:
-			plottable = Plottable(note,FretboardPlotter.scalesToScaleIndexesDictionary[scaleOrChord])
-		else:
-			plottable = Plottable(note,FretboardPlotter.chordsToChordIndexesDictionary[scaleOrChord])
+		# ex scale or chord is a tuple, get right side ("(R 2nd 3rd 4th 5th 6th 7th)", [0, 2, 4, 5, 7, 9, 11])
+		plottable = Plottable(note, scaleOrChordTuple[1])
 		listOfPlottables.append(plottable)
-		graphTitle = "{} {}\n{}".format(note, scaleOrChord, FretboardPlotter.get_plottable_notes(plottable))
+		graphTitle = "{} {}\n{}\n{}".format(note, scaleOrChordDegree, scaleOrChordTuple[0], FretboardPlotter.get_plottable_notes(plottable))
 
 		FretboardPlotter.populate_strings(instrument, tuning)
 		#creating two plots, top right handed, bottom left handed
@@ -258,7 +256,7 @@ class FretboardPlotter:
 
 		to_plot  = {}
 		plottableRoots = []
-		for plottable in plottables:
+		for plottable in listOfPlottables:
 			plottableRoots.append(plottable.get_root())
 			#ex) notes = ['C', 'E', 'G']
 			notes = FretboardPlotter.get_plottable_notes(plottable)
@@ -275,6 +273,8 @@ class FretboardPlotter:
 			#ex: to_plot(C major scale) = {'E': [19, 17, 15, 13, 12, 10, 8, 7, 5, 3, 1, 0], 'A': [19, 17, 15, 14, 12, 10, 8, 7, 5, 3, 2, 0]...
 			# below for loop iterates through EADGBE keys of the map
 
+		# TODO need to figure out a way to draw certain strings twice if the tuning calls for it (ex; EADGBE, DADG)
+		# TODO saved a blank diagram for c major
 		#need to create a list of 1-n where n is number of strings or the length of the tuning string
 		for y_val, stringName in zip(list(range(1, len(tuning) + 1)), tuning):
 			#  looks up the values corresponding to EADGBE keys of find_notes map aka the indexes of the notes that were in the given scale
@@ -352,19 +352,20 @@ fiveStringDropATuning = "fiveStringDropA"
 allNotes = ['C', 'C#', 'Db', 'D', 'D#', 'Eb', 'E', 'F', 'F#', 'Gb' , 'G', 'G#', 'Ab', 'A', 'A#', 'Bb', 'B' ]
 for note in allNotes:
 	for scale in FretboardPlotter.scalesToScaleIndexesDictionary.keys():
-		FretboardPlotter.plot(note, FretboardPlotter.scalesToScaleIndexesDictionary[scale], True, outputDestination.format(note, scale), guitar, FretboardPlotter.tunings[guitar][standardTuning])
-		FretboardPlotter.plot(note, FretboardPlotter.scalesToScaleIndexesDictionary[scale], True, outputDestination.format(note, scale), bass, FretboardPlotter.tunings[bass][standardTuning])
-		FretboardPlotter.plot(note, FretboardPlotter.scalesToScaleIndexesDictionary[scale], True, outputDestination.format(note, scale), bass, FretboardPlotter.tunings[bass][fiveStringStandardTuning])
-		FretboardPlotter.plot(note, FretboardPlotter.scalesToScaleIndexesDictionary[scale], True, outputDestination.format(note, scale), guitar, FretboardPlotter.tunings[guitar][dropDTuning])
-		FretboardPlotter.plot(note, FretboardPlotter.scalesToScaleIndexesDictionary[scale], True, outputDestination.format(note, scale), bass, FretboardPlotter.tunings[bass][dropDTuning])
-		FretboardPlotter.plot(note, FretboardPlotter.scalesToScaleIndexesDictionary[scale], True, outputDestination.format(note, scale), bass, FretboardPlotter.tunings[bass][fiveStringDropDTuning])
-		FretboardPlotter.plot(note, FretboardPlotter.scalesToScaleIndexesDictionary[scale], True, outputDestination.format(note, scale), bass, FretboardPlotter.tunings[bass][fiveStringDropATuning])
+		# note, scaleOrChord, isScale, outputDestination, filePath, instrument, tuning, night=True
+		FretboardPlotter.plot(note, scale, FretboardPlotter.scalesToScaleIndexesDictionary[scale], outputDestination.format(note, scale), guitar, FretboardPlotter.tunings[guitar][standardTuning])
+		FretboardPlotter.plot(note, scale, FretboardPlotter.scalesToScaleIndexesDictionary[scale], outputDestination.format(note, scale), bass, FretboardPlotter.tunings[bass][standardTuning])
+		FretboardPlotter.plot(note, scale, FretboardPlotter.scalesToScaleIndexesDictionary[scale], outputDestination.format(note, scale), bass, FretboardPlotter.tunings[bass][fiveStringStandardTuning])
+		FretboardPlotter.plot(note, scale, FretboardPlotter.scalesToScaleIndexesDictionary[scale], outputDestination.format(note, scale), guitar, FretboardPlotter.tunings[guitar][dropDTuning])
+		FretboardPlotter.plot(note, scale, FretboardPlotter.scalesToScaleIndexesDictionary[scale], outputDestination.format(note, scale), bass, FretboardPlotter.tunings[bass][dropDTuning])
+		FretboardPlotter.plot(note, scale, FretboardPlotter.scalesToScaleIndexesDictionary[scale], outputDestination.format(note, scale), bass, FretboardPlotter.tunings[bass][fiveStringDropDTuning])
+		FretboardPlotter.plot(note, scale, FretboardPlotter.scalesToScaleIndexesDictionary[scale], outputDestination.format(note, scale), bass, FretboardPlotter.tunings[bass][fiveStringDropATuning])
 	for chord in FretboardPlotter.chordsToChordIndexesDictionary.keys():
-		FretboardPlotter.plot(note, FretboardPlotter.chordsToChordIndexesDictionary[chord], False, outputDestination.format(note, chord), guitar, FretboardPlotter.tunings[guitar][standardTuning])
-		FretboardPlotter.plot(note, FretboardPlotter.chordsToChordIndexesDictionary[chord], False, outputDestination.format(note, chord), bass, FretboardPlotter.tunings[bass][standardTuning])
-		FretboardPlotter.plot(note, FretboardPlotter.chordsToChordIndexesDictionary[chord], False, outputDestination.format(note, chord), bass, FretboardPlotter.tunings[bass][fiveStringStandardTuning])
-		FretboardPlotter.plot(note, FretboardPlotter.chordsToChordIndexesDictionary[chord], False, outputDestination.format(note, chord), guitar, FretboardPlotter.tunings[guitar][dropDTuning])
-		FretboardPlotter.plot(note, FretboardPlotter.chordsToChordIndexesDictionary[chord], False, outputDestination.format(note, chord), bass, FretboardPlotter.tunings[bass][dropDTuning])
-		FretboardPlotter.plot(note, FretboardPlotter.chordsToChordIndexesDictionary[chord], False, outputDestination.format(note, chord), bass, FretboardPlotter.tunings[bass][fiveStringDropDTuning])
-		FretboardPlotter.plot(note, FretboardPlotter.chordsToChordIndexesDictionary[chord], False, outputDestination.format(note, chord), bass, FretboardPlotter.tunings[bass][fiveStringDropATuning])
+		FretboardPlotter.plot(note, chord, FretboardPlotter.chordsToChordIndexesDictionary[chord], outputDestination.format(note, chord), guitar, FretboardPlotter.tunings[guitar][standardTuning])
+		FretboardPlotter.plot(note, chord, FretboardPlotter.chordsToChordIndexesDictionary[chord], outputDestination.format(note, chord), bass, FretboardPlotter.tunings[bass][standardTuning])
+		FretboardPlotter.plot(note, chord, FretboardPlotter.chordsToChordIndexesDictionary[chord], outputDestination.format(note, chord), bass, FretboardPlotter.tunings[bass][fiveStringStandardTuning])
+		FretboardPlotter.plot(note, chord, FretboardPlotter.chordsToChordIndexesDictionary[chord], outputDestination.format(note, chord), guitar, FretboardPlotter.tunings[guitar][dropDTuning])
+		FretboardPlotter.plot(note, chord, FretboardPlotter.chordsToChordIndexesDictionary[chord], outputDestination.format(note, chord), bass, FretboardPlotter.tunings[bass][dropDTuning])
+		FretboardPlotter.plot(note, chord, FretboardPlotter.chordsToChordIndexesDictionary[chord], outputDestination.format(note, chord), bass, FretboardPlotter.tunings[bass][fiveStringDropDTuning])
+		FretboardPlotter.plot(note, chord, FretboardPlotter.chordsToChordIndexesDictionary[chord], outputDestination.format(note, chord), bass, FretboardPlotter.tunings[bass][fiveStringDropATuning])
 


### PR DESCRIPTION
Did a handful of refactoring culminating in using Claude to refactor the graph plotting logic (was too lazy to learn matplotlib)

Below are claude's responses to questions I asked it about how to refactor the drawing logic for future reference

---

Yes, I've got it. This is a fretboard diagram generator — it produces PNG images showing where the notes of a given scale or chord fall on a guitar or bass fretboard, for a bunch of instrument/tuning combinations.

The core is the `FretboardPlotter` class, which holds both the music-theory data and the matplotlib drawing logic:

The two chromatic-note lists (`whole_notes_sharps`/`whole_notes_flats`) are tripled so there are always enough notes to look ahead past where each string starts. `chordsToChordIndexesDictionary` and `scalesToScaleIndexesDictionary` are the theory tables — each entry maps a name to a `(human-readable interval string, [semitone offsets from root])` tuple. So a major triad is `[0, 4, 7]`, dorian is `[0, 2, 3, 5, 7, 9, 10]`, etc. Extended chords fold higher extensions back into one octave (e.g. the 9th is stored as `2`).

The pipeline for a single diagram works like this: a `Plottable` bundles a root note plus its interval list. `get_plottable_notes` builds the 12-note chromatic alphabet starting at the root (choosing the sharp or flat spelling based on the root) and indexes into it to get the actual note names — so C + `[0,4,7]` → `['C','E','G']`. `populate_strings` builds, for each open string in the tuning, a 24-fret list of (sharp, flat) note tuples. `find_notes` then walks each string and records the fret positions where those target notes appear. Finally `plot` draws two subplots (right-handed on top, left-handed below), lays down horizontal string lines and vertical fret lines, and stamps a labeled circle at each matching position, with roots drawn larger and in yellow.

The bottom script just brute-forces the whole space: for every note in `allNotes`, it generates diagrams for every scale and every chord across guitar/bass in standard, drop-D, and several 5-string tunings, writing files named like `C major guitar - 6 string EADGBE.png`.

One thing worth flagging up front, since it may come up: because `strings = {i:0 for i in tuning}` uses the tuning string's characters as dict keys, a tuning like `EADGBE` collapses the two E strings into a single key, so you effectively get 5 unique strings rather than 6 — which lines up with the TODO comments about drawing certain strings twice.

What would you like to dig into?\



______

I'll set up the environment, reproduce your current C major diagram so I'm working from exactly what you see, then make the three changes and show you the result.Now let me reproduce your current output. I'll put your code in a file with a minimal runner that produces just the C-major / guitar / standard diagram.That's an exact match to your screenshot, so I'm seeing what you see. Three things are confirmed visible: the top axis is numbered 6/4/2, the bubbles are horizontally-stretched ellipses (so the text isn't sitting centered in a round dot), and the open notes are crammed into a narrow sliver left of the gold nut and clipped at the edge.

Let me rebuild the drawing logic. I'll make the open position a normal-width slot, shorten the board (I'm using a single `NUM_FRETS` constant — defaulting to 15 — so you can dial it), switch the bubbles to text-anchored circles so they're always perfectly centered, and label the top axis with string names.That's all three changes landed. Let me confirm the bass case didn't break (the old code had a TODO that 4- and 5-string were "a mess"):Works for bass too — flats are spelled correctly (Eb/Bb/Gb…) and the 4-string now fills its height instead of floating. One small thing I want to fix: on the shorter bass figure the title's note-list line crowds the top row. Let me reserve title space proportional to figure height so it's clean at any string count, then give you the final files.Both render cleanly now. Here's the result for C major / guitar / standard:All three changes are in:

1. **String names on the top graph** — the right-handed plot now gets a `set_yticks` with the tuning letters, same as the bottom one (the left axis read `6/4/2` only because that branch was never given y-ticks).
2. **Centering** — I dropped the manual `mpatches.Circle` (which was being squashed into an ellipse by the unequal x/y axis scaling) and instead draw each note as text with a `bbox=dict(boxstyle='circle', …)`. The circle is sized to the character and always centered on it, so roots and regular notes both sit dead-center. Roots get a gold ring + yellow text + larger font.
3. **Open notes / shorter board** — the open position (fret 0) is now a normal-width slot left of the gold nut, so open notes draw as full bubbles (yellow if they're the root) instead of being crammed into a sliver and clipped. Board length is a single constant `NUM_FRETS` (set to 15) so you can lengthen/shorten freely.

The changes are surgical — your big chord/scale dictionaries and the execution loop at the bottom are untouched. Here's a patch file with exactly the three spots that change:A couple of notes worth flagging:

You can delete the now-unused `import matplotlib.patches as mpatches` line, since the manual `Circle` patches are gone.

On `mpatches` being removed: the old `i == 0 ? special offset` open-note handling and the 20-vs-24-fret TODOs are all obsolete now — the open slot and fret count are handled uniformly, so you can clear those TODO comments.

One thing I kept deliberately rather than "fixing": the `EADGBE` tuning still collapses to 5 unique string keys because `strings = {i: 0 for i in tuning}` uses the note letters as dict keys, so the two E strings share one entry. It happens to render fine here because both E strings show identical notes, but if you ever want a true 6-row layout (or drop tunings where two strings differ but share a letter), that dict would need to key on string *position* instead of note name. Happy to rework that next if you want it.

Want me to push `NUM_FRETS` lower (12 gives you exactly one octave per string and a very compact diagram), or adjust the root highlight — e.g. a filled gold circle instead of the gold ring?


____

Two changes here: max out the board at 24 frets, and move the open-string notes off the board entirely — instead, the string-label (y-tick) itself gets circled when that open note is in the scale (blue), or gold-ringed when it's the root. So fret 0 disappears as a column and the open info lives on the axis.

Let me build it and verify with C major (all six open strings are in the scale → all six labels circled blue) plus A major (open A is the root → that label should go gold, and open G is *not* in A major → that label should stay plain).C major looks right — all six open-string labels circled blue at the nut, no fret-0 column, 24 frets. Now the A major check, where the open A is the root and the open G isn't in the scale:A major confirms the axis logic end-to-end: open **A** is gold-ringed (it's the root), open **G** stays plain (A major has G♯, not G, so the open G isn't in the scale), and the other four opens are circled blue. Fretted roots on the board still get their gold rings.

Let me sanity-check the flats path and a 4-string bass before handing it over:Bass is clean too — four open labels circled, 24 frets, no clipping. Everything checks out. Here are the final renders and the updated code.Done. Both changes are in the updated patch file:

`NUM_FRETS = 24`, and the open-string slot is gone from the board. Instead, the open note is shown by styling the y-tick string label: blue circle when that open note is in the scale/chord, gold ring + yellow text when it's the root, and left plain when the open note isn't in the scale at all. In C major every open string (E A D G B E) is in the scale, so all six labels circle blue; in A major the open A label goes gold (root) and the open G stays plain because A major has G♯, not G.

The patch is still just three surgical spots — `NUM_FRETS` plus the longer note lists (I bumped `*3` → `*4`, since a 24-fret span needs 25 notes and `*3` only barely covered it), the one-line `populate_strings` slice, and the `plot` method. Your dictionaries and execution loop are untouched.

One unrelated thing I noticed while testing, which predates these edits: for natural-letter roots that should be sharp keys, the spelling comes out as flats. In the A major render the title reads `['A', 'B', 'Db', 'D', 'E', 'Gb', 'Ab']` (it should be C♯/F♯/G♯), and the title spelling doesn't match what the board draws. It traces to `get_plottable_notes` keying off `'#' in root` while the board keys off the flats list in `accidentalsToKeysMap` — the two disagree for roots like A, B, D, E, G. Not something you asked me to touch, so I left it, but happy to reconcile the spelling logic if you want it fixed.


___

Two clean tweaks. Let me make out-of-scale string labels match the others in size/weight (the G *looks* smaller only because it's not bold and lacks the circle — the letter itself was the same point size, so I'll bold it and set a uniform size), and remove the trailing wire after fret 24 while pinning the right edge exactly at fret 24's boundary so every fret stays one unit wide.G is now bold and the same size as the circled labels, and the board ends cleanly at fret 24 with no trailing line or cut-off sliver — every fret is a uniform width. Let me confirm the all-in-scale case (C major) looks right too:Both fixes are in. Let me update the patch file with the final `plot` method and hand everything over.Both changes are done and verified:

**Uniform string labels** — every y-axis string label now gets the same explicit font size (12) and bold weight, applied before the in-scale styling. So in A major the out-of-scale **G** is the same size as the circled E/A/D/B/E; the only difference is the circle and color (which still signal scale membership and root).

**No trailing fret line** — the wire loop now draws `range(N)` wires (the nut plus inner wires) instead of `range(N+1)`, dropping the wire that sat just past fret 24. I paired that with `xlim` ending exactly at the last fret boundary (`N + 0.5` right-handed, `-0.5` left-handed), so fret 24 keeps the same one-unit width as every other fret and the board ends flush instead of showing a clipped "25th fret."

The updated `plot()` in the patch file reflects both. Same three-spot footprint as before — dictionaries and the execution loop untouched.

The note-spelling mismatch I flagged last time (sharp keys like A printing flats in the title) is still present since it's outside what you asked me to change. Say the word and I'll reconcile `get_plottable_notes` with the `accidentalsToKeysMap` logic so the title and board agree.
